### PR TITLE
Add new routes for Anthropic and OpenAI integrations

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,8 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 
+import rootAnthropicRouter from "./routes/anthropic.js";
+import rootOpenaiRouter from "./routes/openai.js";
 import v1Router from "./routes/v1.js";
 import type { Context } from "./types/hono.js";
 import { getConfig } from "./utils/config.js";
@@ -23,6 +25,8 @@ app.get("/", (c) => {
   });
 });
 
+app.route("/anthropic", rootAnthropicRouter);
+app.route("/openai", rootOpenaiRouter);
 app.route("/v1", v1Router);
 
 app.onError((err, c) => {

--- a/src/routes/anthropic.ts
+++ b/src/routes/anthropic.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 LMRouter Contributors
+
+import { Hono } from "hono";
+
+import anthropicRouter from "./v1/anthropic.js";
+import type { Context } from "../types/hono.js";
+
+const rootAnthropicRouter = new Hono<Context>();
+
+rootAnthropicRouter.route("/", anthropicRouter);
+
+export default rootAnthropicRouter;

--- a/src/routes/openai.ts
+++ b/src/routes/openai.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 LMRouter Contributors
+
+import { Hono } from "hono";
+
+import openaiRouter from "./v1/openai.js";
+import type { Context } from "../types/hono.js";
+
+const rootOpenaiRouter = new Hono<Context>();
+
+rootOpenaiRouter.route("/", openaiRouter);
+
+export default rootOpenaiRouter;


### PR DESCRIPTION
- Introduced `rootAnthropicRouter` and `rootOpenaiRouter` to handle requests for the respective APIs.
- Updated `app.ts` to include routing for `/anthropic` and `/openai`, enhancing the application's API structure.
- Created new route files for Anthropic and OpenAI, establishing a clear separation of concerns and improving maintainability.

Fixes #6