### PR TITLE
ci: fix setup-node to read .nvmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ".nvmrc"
+          node-version-file: ".nvmrc"
           cache: "npm"
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
PR #28  

### Summary
Fixes post-merge CI failure caused by using `node-version: ".nvmrc"` in the GitHub Actions workflow.

### Changes
- Switched from `node-version` to `node-version-file` in `setup-node` step.

### Why
`node-version: ".nvmrc"` was interpreted as a literal version string, causing setup-node to fail.  
Using `node-version-file` reads the actual version from `.nvmrc`, allowing the runner to resolve and install the correct Node version

