### PR TITLE
Add model parsing middleware and refactor routes for OpenAI and Anthropic

### DIFF
--- a/src/middlewares/model.ts
+++ b/src/middlewares/model.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 LMRouter Contributors
+
+import { createMiddleware } from "hono/factory";
+
+import type { ContextEnv } from "../types/hono.js";
+import { getModel } from "../utils/utils.js";
+
+export const parseModel = createMiddleware<ContextEnv>(async (c, next) => {
+  const body = await c.req.json();
+  if (!body.model) {
+    return c.json(
+      {
+        error: {
+          message: "Model is required",
+        },
+      },
+      400,
+    );
+  }
+
+  const model = getModel(body.model, c);
+  if (!model) {
+    return c.json(
+      {
+        error: {
+          message: "Model not found",
+        },
+      },
+      404,
+    );
+  }
+  c.set("model", model);
+
+  await next();
+});

--- a/src/routes/v1/openai/v1/images.ts
+++ b/src/routes/v1/openai/v1/images.ts
@@ -11,28 +11,17 @@ import type {
 import { OpenAIImageEditAdapterFactory } from "../../../../adapters/openai/v1/images/edits/adapter.js";
 import { OpenAIImageGenerationAdapterFactory } from "../../../../adapters/openai/v1/images/generations/adapter.js";
 import { auth } from "../../../../middlewares/auth.js";
+import { parseModel } from "../../../../middlewares/model.js";
 import type { ContextEnv } from "../../../../types/hono.js";
-import { getModel, iterateModelProviders } from "../../../../utils/utils.js";
+import { iterateModelProviders } from "../../../../utils/utils.js";
 
 const imagesRouter = new Hono<ContextEnv>();
 
-imagesRouter.use(auth);
+imagesRouter.use(auth, parseModel);
 
 imagesRouter.post("/generations", async (c) => {
   const body = await c.req.json();
-  const model = getModel(body.model, c);
-  if (!model) {
-    return c.json(
-      {
-        error: {
-          message: "Model not found",
-        },
-      },
-      404,
-    );
-  }
-
-  return await iterateModelProviders(model, c, async (modelName, provider) => {
+  return await iterateModelProviders(c, async (modelName, provider) => {
     const reqBody = { ...body } as ImageGenerateParamsBase;
     reqBody.model = modelName;
 
@@ -56,19 +45,7 @@ imagesRouter.post("/generations", async (c) => {
 
 imagesRouter.post("/edits", async (c) => {
   const body = await c.req.json();
-  const model = getModel(body.model, c);
-  if (!model) {
-    return c.json(
-      {
-        error: {
-          message: "Model not found",
-        },
-      },
-      404,
-    );
-  }
-
-  return await iterateModelProviders(model, c, async (modelName, provider) => {
+  return await iterateModelProviders(c, async (modelName, provider) => {
     const reqBody = { ...body } as ImageEditParamsBase;
     reqBody.model = modelName;
 

--- a/src/types/hono.ts
+++ b/src/types/hono.ts
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025 LMRouter Contributors
 
+import type { LMRouterCoreConfigModel } from "../utils/config.js";
+
 export type ContextEnv = {
   Variables: {
     byok?: string;
+    model?: LMRouterCoreConfigModel;
   };
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -8,6 +8,7 @@ import {
   type LMRouterCoreConfigModel,
   type LMRouterCoreConfigProvider,
 } from "./config.js";
+import type { ContextEnv } from "../types/hono.js";
 
 export const getUptime = () => {
   const seconds = Math.floor(process.uptime());
@@ -20,7 +21,7 @@ export const getUptime = () => {
 
 export const getModel = (
   modelName: string,
-  c: Context,
+  c: Context<ContextEnv>,
 ): LMRouterCoreConfigModel | null => {
   const cfg = getConfig(c);
 
@@ -56,14 +57,24 @@ export const getModel = (
 };
 
 export const iterateModelProviders = async (
-  model: LMRouterCoreConfigModel,
-  c: Context,
+  c: Context<ContextEnv>,
   cb: (modelName: string, provider: LMRouterCoreConfigProvider) => Promise<any>,
 ): Promise<any> => {
   const cfg = getConfig(c);
   let error: any = null;
 
-  for (const provider of model.providers) {
+  if (!c.var.model) {
+    return c.json(
+      {
+        error: {
+          message: "Model is not set",
+        },
+      },
+      500,
+    );
+  }
+
+  for (const provider of c.var.model.providers) {
     const providerCfg = cfg.providers[provider.provider];
     if (!providerCfg) {
       continue;


### PR DESCRIPTION
- Introduced `parseModel` middleware to validate and set the model from request bodies, improving error handling for missing or invalid models.
- Updated OpenAI and Anthropic routes to utilize the new middleware, removing redundant model validation logic and enhancing code clarity.
- Adjusted context types to support model information, ensuring consistent access across routes.

Closes #21 